### PR TITLE
Fix pymatgen response fields issue in tutorial

### DIFF
--- a/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
+++ b/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
@@ -1,20 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "OPTIMADE tutorial with pymatgen.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -84,6 +68,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 103,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -91,14 +76,10 @@
         "id": "qU7Uolip7N-g",
         "outputId": "b756287e-3d19-444d-f91c-c4aea6c440a6"
       },
-      "source": [
-        "!pip install pymatgen pybtex retrying"
-      ],
-      "execution_count": 103,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Requirement already satisfied: pymatgen in /usr/local/lib/python3.7/dist-packages (2022.0.14)\n",
             "Requirement already satisfied: pybtex in /usr/local/lib/python3.7/dist-packages (0.24.0)\n",
@@ -135,6 +116,9 @@
             "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.7/dist-packages (from sympy->pymatgen) (1.2.1)\n"
           ]
         }
+      ],
+      "source": [
+        "!pip install pymatgen pybtex retrying"
       ]
     },
     {
@@ -143,22 +127,23 @@
         "id": "f2gK8ZkZ6hMX"
       },
       "source": [
-        "Next, let us **verify the correct version of *pymatgen* is installed**. This is good practice to do before starting out! For this tutorial we need version 2022.0.14 or above. We also need the `pybtex` package installed."
+        "Next, let us **verify the correct version of *pymatgen* is installed**. This is good practice to do before starting out! For this tutorial we need version 2022.0.17 or above (which may not be released at the time of this tutorial). We also need the `pybtex` package installed."
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 104,
       "metadata": {
         "id": "-Briwygk6goF"
       },
+      "outputs": [],
       "source": [
         "from importlib_metadata import version"
-      ],
-      "execution_count": 104,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 105,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -167,13 +152,8 @@
         "id": "zK-818jN7BOo",
         "outputId": "15f22406-261f-4a61-fd25-2c21ca204803"
       },
-      "source": [
-        "version(\"pymatgen\")"
-      ],
-      "execution_count": 105,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "application/vnd.google.colaboratory.intrinsic+json": {
               "type": "string"
@@ -182,9 +162,27 @@
               "'2022.0.14'"
             ]
           },
+          "execution_count": 105,
           "metadata": {},
-          "execution_count": 105
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "version(\"pymatgen\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# There is a bug with 2020.0.15 and 2020.0.16 this has been fixed in a fork, hopefully soon to be merged and added to next pymatgen release\n",
+        "# If this is not available, install directly from GitHub\n",
+        "\n",
+        "# You may not want to run this cell if you are performing the tutorial within your own Python environment\n",
+        "if int(version(\"pymatgen\").split(\".\")[-1]) < 17:\n",
+        "    !pip install git+https://github.com/ml-evs/pymatgen@fix_response_fields"
       ]
     },
     {
@@ -209,14 +207,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 106,
       "metadata": {
         "id": "7l9gvSYz7Evd"
       },
+      "outputs": [],
       "source": [
         "from pymatgen.ext.optimade import OptimadeRester"
-      ],
-      "execution_count": 106,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -229,14 +227,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 107,
       "metadata": {
         "id": "M-UkaQxa82ET"
       },
+      "outputs": [],
       "source": [
         "OptimadeRester?"
-      ],
-      "execution_count": 107,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -249,6 +247,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 108,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -256,13 +255,8 @@
         "id": "7hDTvvXz_ZFk",
         "outputId": "19562289-6c19-488a-8276-965e99152eee"
       },
-      "source": [
-        "OptimadeRester.aliases"
-      ],
-      "execution_count": 108,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "{'aflow': 'http://aflow.org/API/optimade/',\n",
@@ -285,9 +279,13 @@
               " 'tcod': 'https://www.crystallography.net/tcod/optimade'}"
             ]
           },
+          "execution_count": 108,
           "metadata": {},
-          "execution_count": 108
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "OptimadeRester.aliases"
       ]
     },
     {
@@ -305,6 +303,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 109,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -312,27 +311,26 @@
         "id": "tDbwPyUU_isv",
         "outputId": "68ae47fa-3b3c-4ff7-9edc-e14153997cea"
       },
-      "source": [
-        "opt = OptimadeRester()\n",
-        "opt.refresh_aliases()"
-      ],
-      "execution_count": 109,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Connecting to all known OPTIMADE providers, this will be slow. Please connect to only the OPTIMADE providers you want to query. Choose from: aflow, cod, mcloud.2dstructures, mcloud.2dtopo, mcloud.curated-cofs, mcloud.li-ion-conductors, mcloud.optimade-sample, mcloud.pyrene-mofs, mcloud.scdm, mcloud.sssp, mcloud.stoceriaitf, mcloud.tc-applicability, mcloud.threedd, mp, odbx, omdb.omdb_production, oqmd, tcod\n"
           ]
         },
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "\n",
             "odbx: 100%|██████████| 54/54 [00:19<00:00, 26.75it/s]\u001b[A"
           ]
         }
+      ],
+      "source": [
+        "opt = OptimadeRester()\n",
+        "opt.refresh_aliases()"
       ]
     },
     {
@@ -348,14 +346,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 110,
       "metadata": {
         "id": "RmOlXNC2A0wF"
       },
+      "outputs": [],
       "source": [
         "opt = OptimadeRester([\"mp\", \"mcloud.threedd\"])"
-      ],
-      "execution_count": 110,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -368,6 +366,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 111,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -375,20 +374,19 @@
         "id": "wrmCKA5SBFoQ",
         "outputId": "90ad4dcd-bfe7-4f9c-8892-d586e5a46e4b"
       },
-      "source": [
-        "print(opt.describe())"
-      ],
-      "execution_count": 111,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "OptimadeRester connected to:\n",
             "Provider(name='The Materials Project', base_url='https://optimade.materialsproject.org', description='The Materials Project OPTIMADE endpoint', homepage='https://materialsproject.org', prefix='mp')\n",
             "Provider(name='Materials Cloud', base_url='https://aiida.materialscloud.org/3dd/optimade', description='A platform for Open Science built for seamless sharing of resources in computational materials science', homepage='https://materialscloud.org', prefix='mcloud')\n"
           ]
         }
+      ],
+      "source": [
+        "print(opt.describe())"
       ]
     },
     {
@@ -406,6 +404,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 112,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -413,14 +412,10 @@
         "id": "Nq3vHIg-BQpC",
         "outputId": "845250c5-de2f-4f41-d3e7-97e23fee60b6"
       },
-      "source": [
-        "results = opt.get_structures(elements=[\"N\"], nelements=2)"
-      ],
-      "execution_count": 112,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "\n",
             "\n",
@@ -563,6 +558,9 @@
             "mcloud.threedd: 100%|██████████| 87/87 [00:02<00:00, 32.31it/s]"
           ]
         }
+      ],
+      "source": [
+        "results = opt.get_structures(elements=[\"N\"], nelements=2)"
       ]
     },
     {
@@ -578,6 +576,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 113,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -585,25 +584,25 @@
         "id": "pgt2xFziCKmQ",
         "outputId": "18cf5db3-e6a4-47fb-fea0-e8be1b31cebc"
       },
-      "source": [
-        "type(results)  # this method returns a dictionary, so let's examine the keys of this dictionary..."
-      ],
-      "execution_count": 113,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "dict"
             ]
           },
+          "execution_count": 113,
           "metadata": {},
-          "execution_count": 113
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "type(results)  # this method returns a dictionary, so let's examine the keys of this dictionary..."
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 114,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -611,25 +610,25 @@
         "id": "TWpcjldECY3V",
         "outputId": "884967ed-4463-46f4-c762-da898631ae85"
       },
-      "source": [
-        "results.keys()  # we see that the results dictionary is keyed by provider/alias"
-      ],
-      "execution_count": 114,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "dict_keys(['mp', 'mcloud.threedd'])"
             ]
           },
+          "execution_count": 114,
           "metadata": {},
-          "execution_count": 114
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "results.keys()  # we see that the results dictionary is keyed by provider/alias"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 115,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -637,21 +636,20 @@
         "id": "p-gIUNm4Cdho",
         "outputId": "d08bf60a-811f-434a-cee6-1161d4d36982"
       },
-      "source": [
-        "results['mp'].keys()  # and these are then keyed by that database's unique identifier"
-      ],
-      "execution_count": 115,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "dict_keys(['mp-1008610', 'mp-1019271', 'mp-1065394', 'mp-7790', 'mp-1015582', 'mp-1104441', 'mp-1019272', 'mp-1102235', 'mp-29973', 'mp-2245', 'mp-1014303', 'mp-1007824', 'mp-1245326', 'mp-973935', 'mp-834', 'mp-1018160', 'mp-1014298', 'mp-1214623', 'mp-1245013', 'mp-1244914', 'mp-27908', 'mp-32652', 'mp-1216472', 'mp-1014358', 'mp-1018733', 'mp-1009885', 'mp-1058019', 'mp-11660', 'mp-1209181', 'mp-510557', 'mp-1245132', 'mp-1009769', 'mvc-15478', 'mp-1865', 'mp-9981', 'mp-1077354', 'mp-10736', 'mp-1091417', 'mp-1245165', 'mp-1204550', 'mp-1245046', 'mp-661', 'mp-8101', 'mp-1001117', 'mp-2114', 'mp-1008833', 'mp-1008489', 'mp-1009483', 'mp-1188353', 'mp-1245244', 'mp-1077275', 'mp-1271276', 'mp-2828', 'mp-1078568', 'mp-1093992', 'mp-1213154', 'mp-2341', 'mvc-11235', 'mp-1014324', 'mp-1102114', 'mp-1244927', 'mp-634410', 'mp-567617', 'mp-1001826', 'mp-1002222', 'mp-1014995', 'mp-1072543', 'mp-1001916', 'mp-1064529', 'mp-754553', 'mp-1097011', 'mp-1096882', 'mp-1008921', 'mvc-13808', 'mp-1188721', 'mp-1933', 'mp-1097766', 'mp-754353', 'mp-986716', 'mp-1017550', 'mp-1096965', 'mp-1120744', 'mp-13480', 'mp-1180282', 'mp-1079947', 'mp-1212113', 'mp-1954', 'mp-510087', 'mp-27954', 'mp-999496', 'mp-476', 'mp-1018027', 'mp-1080201', 'mp-1096917', 'mp-1245010', 'mp-998899', 'mp-608071', 'mp-1014287', 'mp-1096962', 'mp-1218446', 'mp-1245263', 'mp-1009130', 'mp-1062817', 'mp-1220479', 'mp-251', 'mp-1018849', 'mp-1016048', 'mp-1079684', 'mp-1221793', 'mp-13175', 'mp-570604', 'mp-1009646', 'mp-1410', 'mp-973674', 'mp-1002207', 'mp-1188869', 'mp-1217167', 'mp-570471', 'mp-1060281', 'mp-1080202', 'mp-1179691', 'mp-2565', 'mp-504769', 'mvc-15427', 'mp-1047', 'mp-1096966', 'mp-1173453', 'mp-1019316', 'mp-1245258', 'mp-776470', 'mp-1077346', 'mp-1804', 'mp-2852', 'mp-637209', 'mp-1014264', 'mp-1014316', 'mp-1057758', 'mp-1208632', 'mvc-13729', 'mp-1016058', 'mp-1180215', 'mp-1180313', 'mp-804', 'mp-940', 'mp-984', 'mp-1097042', 'mp-1196421', 'mp-1245106', 'mp-530081', 'mp-1065265', 'mp-604884', 'mp-1008986', 'mp-1078389', 'mp-1015780', 'mp-754628', 'mp-1216464', 'mp-1940', 'mp-2131', 'mp-535', 'mvc-13927', 'mp-1180230', 'mp-1238814', 'mp-2599', 'mp-1014281', 'mp-1008826', 'mp-27488', 'mp-1244991', 'mp-570454', 'mp-779689', 'mp-684642', 'mp-1018734', 'mp-1014565', 'mp-1179882', 'mp-569461', 'mp-754556', 'mp-1009639', 'mp-1015065', 'mp-1096957', 'mp-1009640', 'mp-1077506', 'mp-510350', 'mp-973', 'mp-1017546', 'mp-10564', 'mp-2634', 'mp-568172', 'mp-1017532', 'mp-1013529', 'mp-1187906', 'mp-1200511', 'mp-1195863', 'mp-1271281', 'mp-13146', 'mp-685145', 'mp-1001844', 'mp-1209103', 'mp-1014379', 'mp-1102941', 'mp-1018852', 'mp-1056900', 'mp-1079760', 'mp-11607', 'mp-1193580', 'mp-1015026', 'mp-1097039', 'mp-13098', 'mp-1009649', 'mp-1096909', 'mp-8282', 'mp-1061865', 'mp-1580', 'mp-36891', 'mp-1180345', 'mp-616407', 'mp-883', 'mp-1080197', 'mp-1246153', 'mp-754629', 'mp-1008965', 'mp-1245175', 'mp-13117', 'mp-32590', 'mp-1008820', 'mp-1207010', 'mvc-13455', 'mp-1002229', 'mp-1009720', 'mp-1080242', 'mp-1080623', 'mp-1208477', 'mp-248', 'mp-2789', 'mp-6988', 'mp-971694', 'mp-1079585', 'mp-1204171', 'mp-1245228', 'mp-1096911', 'mp-1101174', 'mp-1181864', 'mp-570538', 'mp-999264', 'mp-1009596', 'mp-1184048', 'mp-1019052', 'mp-1069841', 'mp-1244984', 'mp-1244972', 'mp-32913', 'mp-1009734', 'mp-1222421', 'mp-607371', 'mp-1067139', 'mp-1245229', 'mp-676', 'mp-864647', 'mp-1066400', 'mp-1096924', 'mp-1225746', 'mp-925', 'mp-1014454', 'mp-1078828', 'mp-1105655', 'mp-755988', 'mp-1014214', 'mp-1080193', 'mp-1220310', 'mp-684592', 'mp-754434', 'mp-1009767', 'mp-1245130', 'mp-1244934', 'mp-569957', 'mp-1062345', 'mp-6933', 'mp-870', 'mp-999263', 'mp-1072167', 'mp-1080198', 'mp-1096961', 'mp-1245281', 'mp-999195', 'mp-1203253', 'mp-1205002', 'mp-1245322', 'mp-1078816', 'mp-999266', 'mp-1018948', 'mp-1104403', 'mp-1639', 'mp-581833', 'mp-1599', 'mp-1080203', 'mp-1220830', 'mp-20812', 'mp-504768', 'mp-601223', 'mp-8102', 'mp-1066162', 'mp-2033', 'mp-1208406', 'mp-2596', 'mp-999485', 'mp-1101901', 'mp-1193871', 'mp-18337', 'mp-999469', 'mp-1009219', 'mp-1009015', 'mp-1096918', 'mp-1201150', 'mp-1014478', 'mp-1018655', 'mp-999296', 'mp-1102429', 'mp-583712', 'mp-1018049', 'mp-1014345', 'mp-1077096', 'mp-1184774', 'mp-684692', 'mvc-13841', 'mp-1078791', 'mp-1719', 'mp-1002197', 'mp-637576', 'mp-999294', 'mp-2117', 'mp-567885', 'mp-571653', 'mp-1198545', 'mp-1009836', 'mp-1015612', 'mp-1244872', 'mp-973933', 'mp-980941', 'mp-22631', 'mp-6913', 'mp-999517', 'mp-2653', 'mp-1096890', 'mp-1014509', 'mp-1019239', 'mp-1180334', 'mp-1187056', 'mp-1189035', 'mp-1224501', 'mp-555136', 'mp-1002181', 'mp-1002182', 'mp-1014311', 'mp-1019086', 'mp-1104513', 'mp-12981', 'mp-1064647', 'mp-1097032', 'mp-1244946', 'mp-673635', 'mp-2701', 'mp-1018157', 'mp-1014347', 'mp-1014296', 'mp-1058586', 'mp-1180473', 'mp-1019083', 'mp-1079812', 'mp-1190322', 'mp-685209', 'mp-1225831', 'mp-1096899', 'mp-1078576', 'mp-1080172', 'mp-1096913', 'mp-1096900', 'mp-13173', 'mp-568293', 'mp-1180500', 'mp-569167', 'mp-972036', 'mp-1016073', 'mp-1212961', 'mp-1707', 'mp-1001834', 'mp-1330', 'mp-684887', 'mp-1008823', 'mp-1064119', 'mp-1066707', 'mp-1080199', 'mp-1009601', 'mp-1014342', 'mp-1014339', 'mp-1211954', 'mp-343', 'mp-672264', 'mp-1009078', 'mp-1077299', 'mp-1096893', 'mp-1188048', 'mp-982734', 'mp-1097757', 'mp-1180757', 'mp-1419', 'mp-1975', 'mp-998908', 'mp-1009237', 'mp-1096888', 'mp-1173647', 'mp-1183691', 'mp-33090', 'mp-641541', 'mp-1016069', 'mp-1202811', 'mp-1219567', 'mp-13035', 'mp-2118', 'mp-1009694', 'mp-563', 'mp-1009833', 'mp-1096935', 'mp-1244866', 'mp-1225758', 'mp-1096968', 'mp-1220726', 'mp-13099', 'mp-1776', 'mp-534', 'mp-1120742', 'mp-1190632', 'mp-1245149', 'mp-1244917', 'mp-20304', 'mp-680640', 'mp-1014332', 'mp-749', 'mp-1079708', 'mp-2493', 'mp-1195888', 'mp-1214748', 'mp-971684', 'mp-1014318', 'mp-1179538', 'mp-8046', 'mp-864918', 'mp-998903', 'mvc-11162', 'mvc-11231', 'mp-1014366', 'mp-1190039', 'mp-567290', 'mp-975606', 'mp-999357', 'mp-1009545', 'mp-1078609', 'mp-1096907', 'mp-40793', 'mp-620058', 'mp-1014910', 'mp-1019080', 'mp-1097803', 'mp-16031', 'mp-827', 'mp-1209413', 'mp-1245048', 'mp-1180438', 'mp-1245193', 'mp-1080190', 'mp-1245', 'mp-7927', 'mp-999495', 'mp-1057084', 'mp-1245002', 'mp-1206425', 'mp-1097059', 'mp-1245123', 'mp-685023', 'mp-1080194', 'mp-1192688', 'mp-641539', 'mp-999303', 'mp-1205065', 'mp-1245075', 'mp-13151', 'mp-754381', 'mp-1102', 'mp-22003', 'mp-999355', 'mp-1009548', 'mp-20340', 'mp-1642', 'mp-344', 'mp-651723', 'mp-11801', 'mp-1245172', 'mp-755880', 'mp-1014297', 'mp-1001', 'mp-1008600', 'mp-1014558', 'mp-1019077', 'mp-1095181', 'mp-1009657', 'mp-1245188', 'mp-1245295', 'mp-13148', 'mp-1194075', 'mp-998900', 'mp-1008918', 'mp-1096928', 'mp-1196867', 'mp-1245150', 'mp-2355', 'mvc-14553', 'mp-1096898', 'mp-1216242', 'mp-1245095', 'mp-13178', 'mp-13076', 'mp-2132', 'mp-1009831', 'mp-1007778', 'mp-1210764', 'mp-1096896', 'mp-1178600', 'mp-1218021', 'mp-13034', 'mp-15799', 'mp-988', 'mp-10196', 'mp-1058549', 'mp-1103129', 'mp-1182172', 'mp-1009766', 'mp-1096906', 'mp-1224686', 'mp-1019082', 'mp-467', 'mp-636839', 'mp-1008483', 'mp-1203301', 'mp-13132', 'mp-568867', 'mp-1019078', 'mp-1096914', 'mp-2659', 'mp-999197', 'mp-1058689', 'mp-1245301', 'mp-864675', 'mp-1244896', 'mp-2811', 'mp-567907', 'mp-6977', 'mp-1066', 'mp-1205986', 'mp-1245252', 'mp-1224383', 'mp-720515', 'mp-1009493', 'mp-1018947', 'mp-974435', 'mp-1014265', 'mp-1008798', 'mp-1064952', 'mp-1013524', 'mp-1009732', 'mp-1225203', 'mp-999117', 'mp-999292', 'mp-1096951', 'mp-568862', 'mp-1244916', 'mp-256', 'mp-1059612', 'mp-1080192', 'mp-1106142', 'mp-1185783', 'mp-20411', 'mp-985299', 'mp-1216967', 'mp-2251', 'mp-971657', 'mp-1016076', 'mp-1016071', 'mp-1097796', 'mp-7139', 'mp-981366', 'mp-991', 'mp-1009485', 'mp-34761', 'mp-643432', 'mp-1015076', 'mp-1173466', 'mp-1244943', 'mp-13150', 'mp-608366', 'mp-673174', 'mp-1096892', 'mp-1103420', 'mp-1245231', 'mp-1019319', 'mp-1245069', 'mp-1182484', 'mp-9460', 'mp-542738', 'mp-1059160', 'mp-1180220', 'mp-1057979', 'mp-1096919', 'mp-1103897', 'mp-1459', 'mp-1352', 'mp-1559', 'mp-235', 'mp-448', 'mp-1244977', 'mp-22777', 'mp-1009019', 'mp-1204579', 'mp-1216851', 'mp-1064161', 'mp-1245286', 'mp-21476', 'mp-1018142', 'mp-1019055', 'mp-1096889', 'mp-830', 'mp-1014286', 'mp-1096864', 'mp-1120827', 'mp-1700', 'mp-1221446', 'mp-29145', 'mp-1245233', 'mp-8780', 'mp-980940', 'mp-1203286', 'mp-570572', 'mp-1009005', 'mp-1009471', 'mp-1180808', 'mp-776343', 'mp-864757', 'mp-1077595', 'mp-1220519', 'mp-644751', 'mp-9410', 'mp-555', 'mp-1078219', 'mp-1244884', 'mp-571297', 'mp-685079', 'mp-1101173', 'mp-1102441', 'mp-999300', 'mp-1094090', 'mp-1097018', 'mp-22387', 'mp-685050', 'mp-1016078', 'mp-1245249', 'mp-999307', 'mp-1014373', 'mp-32584', 'mp-1095618', 'mp-32742', 'mp-415', 'mp-1056955', 'mp-1080032', 'mp-20839', 'mp-999293', 'mp-1066821', 'mp-1096908', 'mp-1245302', 'mp-1059879', 'mp-574424', 'mp-7234', 'mp-999473', 'mp-1009049', 'mp-1018716', 'mp-1203025', 'mp-236', 'mp-1009770', 'mp-1064706', 'mp-1198478', 'mp-1207164', 'mp-23922', 'mp-7991', 'mp-999317', 'mp-1105105', 'mp-1205447', 'mp-636056', 'mp-999086', 'mp-1244886', 'mp-27953', 'mp-542635', 'mvc-15387', 'mp-1016070', 'mp-1217984', 'mp-1009818', 'mp-1077232', 'mp-1080196', 'mp-1096886', 'mvc-13461', 'mp-569228', 'mp-971683', 'mp-1008929', 'mp-1009838', 'mp-1245148', 'mp-1245287', 'mp-684744', 'mvc-15664', 'mp-1013528', 'mp-1080200', 'mp-1206884', 'mp-1279', 'mp-2853', 'mp-973785', 'mp-1892', 'mp-1008987', 'mp-1009494', 'mp-1180208', 'mp-1244995', 'mp-1245181', 'mp-1014333', 'mp-1097738', 'mp-13174', 'mp-672289', 'mp-1018018', 'mp-1016081', 'mp-1147700', 'mp-1245030', 'mp-1071980', 'mp-1187591', 'mp-22205', 'mp-32994', 'mp-999503', 'mp-1009496', 'mp-1064272', 'mp-1096894', 'mp-1101868', 'mp-1014444', 'mp-1071531', 'mp-1080191', 'mp-1102074', 'mvc-15384', 'mp-27943', 'mp-2718', 'mp-1078930', 'mp-1244903', 'mp-569655', 'mp-971682', 'mp-1206907', 'mp-973835', 'mp-1188347', 'mp-1212209', 'mp-1007660', 'mp-1104073', 'mp-1008922', 'mp-1016063', 'mp-1067644', 'mp-1173210', 'mp-1103427', 'mp-1217048', 'mp-1008762', 'mp-1019238', 'mp-1070456', 'mvc-13303', 'mp-1008985', 'mp-1014160', 'mp-1002209', 'mp-866083', 'mp-1096901', 'mp-13116', 'mp-2075', 'mp-1096885', 'mp-1188944', 'mp-1224391', 'mp-674509', 'mp-2857', 'mp-31000', 'mp-1015567', 'mp-1014369', 'mp-1016059', 'mp-1071868', 'mp-13126', 'mp-999295', 'mp-1009488', 'mp-1096994', 'mp-1180489', 'mp-2639', 'mp-492', 'mp-1224698', 'mp-540572', 'mp-277', 'mp-743', 'mp-1017982', 'mp-1017533', 'mp-1096903', 'mp-1101178', 'mp-1079438', 'mp-1244975', 'mp-12857', 'mp-603694', 'mp-667338', 'mp-1072204', 'mp-1102371', 'mp-844', 'mp-1014993', 'mp-1200550', 'mp-1224388', 'mp-1771', 'mp-1008558', 'mp-1001828', 'mp-1015908', 'mp-1079251', 'mp-1096931', 'mp-12120', 'mp-1245297', 'mvc-13772', 'mp-1214163', 'mp-22762', 'mp-1096910', 'mp-1096912', 'mp-1245288', 'mp-21264', 'mp-1217441', 'mp-13036', 'mp-776321', 'mvc-11196', 'mp-1058151', 'mp-1101975', 'mp-1179622', 'mp-1220496', 'mp-27461', 'mp-13852', 'mp-2686', 'mp-1009750', 'mp-1188283', 'mp-33046', 'mp-971911', 'mp-1182030', 'mvc-14624', 'mp-1017987', 'mp-1080204', 'mp-1245014', 'mp-2247', 'mp-571281', 'mp-1180221', 'mp-1225892', 'mp-1008923', 'mp-1002117', 'mp-1018648', 'mp-557865', 'mp-1225717', 'mp-1245033', 'mp-505622', 'mp-1014365', 'mp-1188007', 'mp-1002105', 'mp-11661', 'mp-1221525', 'mp-1080195', 'mp-629015', 'mp-1009128', 'mp-1009495', 'mp-1094084', 'mp-1189239', 'mp-1008809', 'mp-1009221', 'mp-1059462', 'mp-999549', 'mp-1245138', 'mp-1985', 'mp-570155', 'mp-16730', 'mp-1497', 'mp-1063003', 'mp-1096922', 'mp-1100774', 'mp-1102681', 'mp-1244998', 'mp-1018851', 'mp-1064715', 'mp-1096934', 'mp-1226927', 'mp-19830', 'mp-1244870', 'mp-1205092', 'mp-866056', 'mp-1014460', 'mp-1219988'])"
             ]
           },
+          "execution_count": 115,
           "metadata": {},
-          "execution_count": 115
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "results['mp'].keys()  # and these are then keyed by that database's unique identifier"
       ]
     },
     {
@@ -665,6 +663,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 116,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -672,15 +671,10 @@
         "id": "WRxgOpFMCm9t",
         "outputId": "c1dee368-e7be-48c9-a711-7300bb3bf856"
       },
-      "source": [
-        "example_structure = results['mp']['mp-804']\n",
-        "print(example_structure)"
-      ],
-      "execution_count": 116,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Full Formula (Ga2 N2)\n",
             "Reduced Formula: GaN\n",
@@ -695,6 +689,10 @@
             "  3  N     0.333333  0.666667  0.37588\n"
           ]
         }
+      ],
+      "source": [
+        "example_structure = results['mp']['mp-804']\n",
+        "print(example_structure)"
       ]
     },
     {
@@ -708,6 +706,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 117,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -715,40 +714,36 @@
         "id": "cQnh2J6PClsU",
         "outputId": "c8cdc6f9-00a4-4e5d-f73f-4dd86e72fbee"
       },
-      "source": [
-        "example_structure.get_space_group_info()"
-      ],
-      "execution_count": 117,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "('P6_3mc', 186)"
             ]
           },
+          "execution_count": 117,
           "metadata": {},
-          "execution_count": 117
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "example_structure.get_space_group_info()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 118,
       "metadata": {
-        "id": "DdkFGoLu78yn",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "DdkFGoLu78yn",
         "outputId": "1e750eba-f180-40ba-d022-ff37429109e3"
       },
-      "source": [
-        "print(example_structure.to(fmt=\"cif\", symprec=0.01))"
-      ],
-      "execution_count": 118,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "# generated using pymatgen\n",
             "data_GaN\n",
@@ -792,6 +787,9 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "print(example_structure.to(fmt=\"cif\", symprec=0.01))"
       ]
     },
     {
@@ -814,20 +812,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 119,
       "metadata": {
         "id": "1ox0FPvvE-Id"
       },
+      "outputs": [],
       "source": [
         "import pandas as pd"
-      ],
-      "execution_count": 119,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 120,
       "metadata": {
         "id": "QIzNLNQVFGA4"
       },
+      "outputs": [],
       "source": [
         "records = []\n",
         "for provider, structures in results.items():\n",
@@ -841,12 +841,11 @@
         "            \"volume\": structure.volume,\n",
         "        })\n",
         "df = pd.DataFrame(records)"
-      ],
-      "execution_count": 120,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 121,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -855,13 +854,8 @@
         "id": "OZIeQr6xFi8D",
         "outputId": "d5f7010d-0970-4507-df37-c2f6645ac9e0"
       },
-      "source": [
-        "df"
-      ],
-      "execution_count": 121,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "<div>\n",
@@ -1012,9 +1006,13 @@
               "[979 rows x 6 columns]"
             ]
           },
+          "execution_count": 121,
           "metadata": {},
-          "execution_count": 121
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df"
       ]
     },
     {
@@ -1028,6 +1026,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 122,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1035,13 +1034,8 @@
         "id": "p5cge1ulFkqX",
         "outputId": "e503d0e9-dc48-48e1-f630-1777940b19f3"
       },
-      "source": [
-        "df[df[\"formula\"] == \"GaN\"].spacegroup"
-      ],
-      "execution_count": 122,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "11     P6_3/mmc\n",
@@ -1091,9 +1085,13 @@
               "Name: spacegroup, dtype: object"
             ]
           },
+          "execution_count": 122,
           "metadata": {},
-          "execution_count": 122
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df[df[\"formula\"] == \"GaN\"].spacegroup"
       ]
     },
     {
@@ -1120,17 +1118,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 123,
       "metadata": {
         "id": "6oeo_5YEI4qg"
       },
+      "outputs": [],
       "source": [
         "import plotly.express as px"
-      ],
-      "execution_count": 123,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 124,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1139,13 +1138,8 @@
         "id": "Gddx0gRdI6bd",
         "outputId": "676da693-e222-413d-804f-7731d40e35f7"
       },
-      "source": [
-        "px.bar(df, x=\"spacegroup\", facet_row=\"provider\")"
-      ],
-      "execution_count": 124,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
             "text/html": [
               "<html>\n",
@@ -1181,8 +1175,12 @@
               "</html>"
             ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "px.bar(df, x=\"spacegroup\", facet_row=\"provider\")"
       ]
     },
     {
@@ -1222,6 +1220,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 125,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1229,14 +1228,10 @@
         "id": "tPYRnwpiHqwc",
         "outputId": "c306708c-8c78-474a-af4d-ccea2e6b4b63"
       },
-      "source": [
-        "results = opt.get_structures_with_filter('(elements HAS ALL \"N\") AND (nelements=2)')"
-      ],
-      "execution_count": 125,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "\n",
             "mp:   2%|▏         | 20/892 [00:00<?, ?it/s]\u001b[A\n",
@@ -1291,6 +1286,9 @@
             "mcloud.threedd: 100%|██████████| 87/87 [00:02<00:00, 31.86it/s]"
           ]
         }
+      ],
+      "source": [
+        "results = opt.get_structures_with_filter('(elements HAS ALL \"N\") AND (nelements=2)')"
       ]
     },
     {
@@ -1308,6 +1306,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 126,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1315,14 +1314,10 @@
         "id": "XqvfXpXgIafz",
         "outputId": "f5619590-1051-40f6-d7b3-11725144792a"
       },
-      "source": [
-        "results_snls = OptimadeRester(\"odbx\").get_snls(nelements=2)"
-      ],
-      "execution_count": 126,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "\n",
             "\n",
@@ -1333,21 +1328,25 @@
             "odbx: 100%|██████████| 54/54 [00:01<00:00, 27.29it/s]\u001b[A\u001b[A"
           ]
         }
+      ],
+      "source": [
+        "results_snls = OptimadeRester(\"odbx\").get_snls(nelements=2)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 127,
       "metadata": {
         "id": "M2T0dGN0Khsm"
       },
+      "outputs": [],
       "source": [
         "example_snl = results_snls['odbx']['odbx/2']"
-      ],
-      "execution_count": 127,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 128,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1355,13 +1354,8 @@
         "id": "qV--VAdvNrKn",
         "outputId": "56d0e3b0-56c8-4664-8dbb-11c9c5f1758d"
       },
-      "source": [
-        "example_snl.data['_optimade']['_odbx_thermodynamics']"
-      ],
-      "execution_count": 128,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "{'enthalpy': -816.9762466666666,\n",
@@ -1371,9 +1365,13 @@
               " 'total_energy': -816.9727734428334}"
             ]
           },
+          "execution_count": 128,
           "metadata": {},
-          "execution_count": 128
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "example_snl.data['_optimade']['_odbx_thermodynamics']"
       ]
     },
     {
@@ -1410,5 +1408,21 @@
         "New developers are very welcome to add code to *pymatgen*! If you want to get involved, help fix bugs or add new features, your help would be very much appreciated. *pymatgen* can only exist and be what it is today thanks to the many efforts of its [development team](https://pymatgen.org/team.html)."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "OPTIMADE tutorial with pymatgen.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
+++ b/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
@@ -138,7 +138,10 @@
       },
       "outputs": [],
       "source": [
-        "from importlib_metadata import version"
+        "try:\n",
+        "    from importlib_metadata import version\n",
+        "except ImportError:\n",
+        "    from importlib.metadata import version"
       ]
     },
     {

--- a/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
+++ b/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
@@ -1330,7 +1330,7 @@
         }
       ],
       "source": [
-        "results_snls = OptimadeRester(\"odbx\").get_snls(nelements=2)"
+        "results_snls = OptimadeRester(\"odbx\").get_snls(nelements=2, additional_response_fields=[\"_odbx_thermodynamics\"])"
       ]
     },
     {

--- a/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
+++ b/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
@@ -182,7 +182,7 @@
         "\n",
         "# You may not want to run this cell if you are performing the tutorial within your own Python environment\n",
         "if int(version(\"pymatgen\").split(\".\")[-1]) < 17:\n",
-        "    !pip install git+https://github.com/ml-evs/pymatgen@fix_response_fields"
+        "    !pip install git+https://github.com/materialsproject/pymatgen@master"
       ]
     },
     {
@@ -1420,7 +1420,8 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "name": "python",
+      "version": "3.9.7"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Add temporary workaround for #8 by pinning pymatgen to fixed/forked version.

This PR can be tested at [Colab](https://colab.research.google.com/github/Materials-Consortia/optimade-tutorial-exercises/blob/ml-evs/pymatgen_response_fields/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb) and [Binder](https://mybinder.org/v2/gh/Materials-Consortia/optimade-tutorial-exercises/ml-evs/pymatgen_response_fields?labpath=notebooks%2Fdemonstration-pymatgen-for-optimade-queries.ipynb).