### PR TITLE
Added timeout and used mcloud.2dstructures instead of mcloud.threedd

### DIFF
--- a/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
+++ b/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
@@ -346,7 +346,9 @@
       "source": [
         "# Connecting to one or more OPTIMADE providers\n",
         "\n",
-        "Let's begin by connecting to the Materials Project (`mp`) and Materials Cloud \"3DD\" (`mcloud.threedd`) databases."
+        "Let's begin by connecting to the Materials Project (`mp`) and Materials Cloud \"2D Structures\" (`mcloud.2dstructures`) databases.\n",
+        "By default pymatgen expects a server to reply within 5 seconds, some servers however require up to several minutes to process a querry.\n",
+        "You can therefore set the timeout to a different value (in seconds) if you get a \"Read timed out\" error."
       ]
     },
     {
@@ -357,7 +359,7 @@
       },
       "outputs": [],
       "source": [
-        "opt = OptimadeRester([\"mp\", \"mcloud.threedd\"])"
+        "opt = OptimadeRester([\"mp\", \"mcloud.2dstructures\"],timeout=10)"
       ]
     },
     {


### PR DESCRIPTION
The 3DD database is still in beta and therefore not always online. Therefore, I have replaced it with the materials cloud 2dmaterials  database.
I however noticed that this database sometimes takes longer than 5 seconds to reply, so I increased the timeout time.
I think there are more databases that do not reply very quickly, so I think it would be good for the students to know about the timeout field anyway. 