### PR TITLE
Update demonstration-pymatgen-for-optimade-queries.ipynb

### DIFF
--- a/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
+++ b/notebooks/demonstration-pymatgen-for-optimade-queries.ipynb
@@ -464,7 +464,7 @@
     "            \"provider\": provider,\n",
     "            \"identifier\": identifier,\n",
     "            \"formula\": structure.composition.reduced_formula,\n",
-    "            \"spacegroup\": structure.get_space_group_info()[0],\n",
+    "            \"spacegroup\": structure.get_space_group_info(angle_tolerance=5.0))[0],\n",
     "            \"a_lattice_param\": structure.lattice.a,\n",
     "            \"volume\": structure.volume,\n",
     "        })\n",


### PR DESCRIPTION
When executing this part of the notebook, I got an error message: "spglib: Too many lattice symmetries was found."
By setting the angle tolerance, this error message ca be avoided. 

I also get the error No point group was found (line 405, /project/src/pointgroup.c) but I am not sure whether I can simply reduce the tolerance here or that every structure should have a point group.